### PR TITLE
Return default corrections when brightness file is missing

### DIFF
--- a/src/brightness.adb
+++ b/src/brightness.adb
@@ -2,8 +2,10 @@
 
 -- Author    : David Haley
 -- Created   : 02/07/2019
--- Last Edit : 09/04/2025
+-- Last Edit : 15/03/2026
 
+-- 20260315 : Return default corrections when brightness file is missing
+--            instead of re-raising, preventing silent main task termination.
 -- 20250409 : Reporting of brightness file modification time.
 -- 20250405 : Minimum_Brightness, Chime_Brightness and Gamma removed to gereral
 -- configuration. DJH.Parse_CSV used to read in corrections. Brightness Records
@@ -65,7 +67,9 @@ package body Brightness is
                  Local_Image (Modification_Time (Compose (Name => File_Name,
                  Extension => Backup_Extension))));
             else
-               raise CSV_Error with "Brightness file not found";
+               Put_Event ("Brightness backup file not found, using default" &
+                            " corrections (" & Default_Correction'Img & ").");
+               return Dot_Correction;
             end if; -- Exists (Compose (Name => File_Name ...
          end if; -- Exists (Compose (Name => File_Name ...
       exception


### PR DESCRIPTION
## Summary
- When both `Brightness.csv` and `Brightness.bak` are absent, `Read_Brightness_Config` previously re-raised the exception after logging it
- This exception occurred in the **declaration section** of `IOT_Clock` (`Dot_Correction := Read_Brightness_Config`), which bypasses the procedure's own exception handler in Ada — causing the main task to silently terminate while child tasks (`UI_Server`, `Strike_Hour`, `Run_Commands`) kept running
- Fix: return the default all-31 correction array with an event log message instead of re-raising

## Test plan
- [ ] Merge `pah/simulator` branch first so this can be tested via Docker sim
- [ ] Run sim **without** `Brightness.csv` present — clock should start normally with uniform brightness rather than appearing deadlocked
- [ ] Verify `Event_Log.txt` contains "Brightness backup file not found, using default corrections" message
- [ ] Confirm `"IOT_Clock version ... started"` appears in the log (previously absent when file was missing)

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)