### PR TITLE
expose web bridge on LAN; add run_bridge.sh for real-clock access

### DIFF
--- a/docker/run_sim.sh
+++ b/docker/run_sim.sh
@@ -45,13 +45,16 @@ docker run --rm --platform linux/arm64 \
 
 echo ""
 echo "Simulation binary built at Clock/obj_sim/iot_clock"
-echo "Running clock + bridge (WebSocket on ws://localhost:8765)..."
+echo "Running clock + bridge..."
+echo "  Simulator WebSocket: ws://localhost:8765  (or open web/index.html as a file)"
+echo "  For a real clock:    ./web/run_bridge.sh <clock-host>"
 echo "  Stop with: docker stop ${CONTAINER_NAME}  (or Ctrl-C)"
 echo ""
 
 # ── Run Ada clock + bridge together ─────────────────────────────────────────
 # Bridge runs inside the container so it talks to Ada via 127.0.0.1 (no NAT).
-# Only TCP port 8765 (WebSocket) is exposed to the Mac.
+# Only TCP port 8765 (WebSocket) is forwarded to the Mac; the bridge binds
+# to all interfaces inside the container (Docker controls external access).
 docker run --rm \
     --name "$CONTAINER_NAME" \
     --platform linux/arm64 \

--- a/web/bridge.py
+++ b/web/bridge.py
@@ -8,6 +8,12 @@ Forwards browser JSON commands back as Request_Records binary to port 50003.
 
 Usage:
     uv run bridge.py [clock-host]   # default: 127.0.0.1
+    BRIDGE_HTTP_PORT=8000 uv run --with websockets web/bridge.py [clock-host]
+                                        # also serves web/ on HTTP port 8000
+
+Environment variables:
+    BRIDGE_WS_HOST   WebSocket bind address (default: 0.0.0.0)
+    BRIDGE_HTTP_PORT HTTP port for serving web/ files; 0 = disabled (default: 0)
 
 ─── Ada wire layout (aarch64 little-endian, GNAT defaults) ──────────────────
 
@@ -60,7 +66,10 @@ import os
 import socket
 import struct
 import sys
+import threading
 from datetime import datetime, timezone
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from pathlib import Path
 
 import websockets
 from websockets.server import serve
@@ -69,8 +78,9 @@ from websockets.server import serve
 CLOCK_HOST    = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
 REQUEST_PORT  = 50003
 RESPONSE_PORT = 50004
-WS_HOST       = os.environ.get("BRIDGE_WS_HOST", "localhost")
+WS_HOST       = os.environ.get("BRIDGE_WS_HOST", "0.0.0.0")
 WS_PORT       = 8765
+HTTP_PORT     = int(os.environ.get("BRIDGE_HTTP_PORT", "0"))
 
 INTERFACE_VERSION = b"20250510"
 
@@ -99,6 +109,15 @@ assert REQUEST_SIZE == 16,  f"REQUEST_FMT calcsize={REQUEST_SIZE}, expected 16"
 
 _STATUS_STRUCT  = struct.Struct(STATUS_FMT)
 _REQUEST_STRUCT = struct.Struct(REQUEST_FMT)
+
+# ── Optional HTTP static file server ──────────────────────────────────────────
+def _start_http_server(port: int) -> None:
+    """Serve the web/ directory over HTTP for LAN access."""
+    web_dir = str(Path(__file__).parent)
+    handler = lambda *a, **kw: SimpleHTTPRequestHandler(*a, directory=web_dir, **kw)
+    server = HTTPServer(("", port), handler)
+    logging.info("HTTP file server: http://0.0.0.0:%d/index.html", port)
+    server.serve_forever()
 
 # ── Ada Calendar.Time decoding ────────────────────────────────────────────────
 def decode_ada_time(ns: int) -> str:
@@ -232,6 +251,9 @@ async def main() -> None:
 
     logging.info("WebSocket server: ws://%s:%d", WS_HOST, WS_PORT)
     logging.info("Forwarding requests → %s:%d", CLOCK_HOST, REQUEST_PORT)
+
+    if HTTP_PORT > 0:
+        threading.Thread(target=_start_http_server, args=(HTTP_PORT,), daemon=True).start()
 
     async with serve(ws_handler, WS_HOST, WS_PORT):
         await asyncio.gather(udp_receive_loop(_udp_tx), poll_clock(_udp_tx))

--- a/web/debug_raw_bytes.py
+++ b/web/debug_raw_bytes.py
@@ -37,13 +37,13 @@ def hexdump(data, width=16):
         ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
         print(f"  {i:4d}  {hex_part:<{width*3}}  {ascii_part}")
 
-# Field layout for annotation
+# Field layout for annotation (matches bridge.py STATUS_FMT: <8sB?8s6xq??2xiHH80s160?)
 FIELDS = [
     (0,   8,  "Clock_Version (String 1..8)"),
-    (8,   4,  "Request (enum uint32)"),
-    (12,  1,  "Diagnostic_Toggle (bool)"),
-    (13,  8,  "User_Interface_Version (String 1..8)"),
-    (21,  3,  "padding (3x)"),
+    (8,   1,  "Request (enum uint8)"),
+    (9,   1,  "Diagnostic_Toggle (bool)"),
+    (10,  8,  "User_Interface_Version (String 1..8)"),
+    (18,  6,  "padding (6x)"),
     (24,  8,  "Current_Time (int64 ns)"),
     (32,  1,  "Chime_Enabled (bool)"),
     (33,  1,  "Chime_Toggle (bool)"),

--- a/web/index.html
+++ b/web/index.html
@@ -581,7 +581,8 @@ document.getElementById('pcb-details-btn').addEventListener('click', () => {
 });
 
 // ── WebSocket ──────────────────────────────────────────────────────────────
-const WS_URL = 'ws://localhost:8765';
+const _wsHost = (location.hostname && location.hostname !== '') ? location.hostname : 'localhost';
+const WS_URL = `ws://${_wsHost}:8765`;
 let ws = null;
 let reconnectTimer = null;
 

--- a/web/run_bridge.sh
+++ b/web/run_bridge.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run the WebSocket bridge for a real physical clock on the LAN.
+#
+# Usage:
+#   ./web/run_bridge.sh <clock-host>
+#
+# Opens the web UI on HTTP port 8000 and the WebSocket bridge on port 8765.
+# On another machine on the same LAN, open:
+#   http://<this-machine-ip>:8000/index.html
+#
+# The clock must have UDP ports 50003 and 50004 reachable from this machine.
+set -e
+
+CLOCK_HOST="${1:?Usage: $(basename "$0") <clock-host>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Connecting to clock at: ${CLOCK_HOST}"
+echo "Web UI:                 http://localhost:8000/index.html"
+echo "WebSocket:              ws://0.0.0.0:8765"
+echo "Press Ctrl-C to stop."
+echo ""
+
+BRIDGE_HTTP_PORT=8000 uv run --with websockets "$SCRIPT_DIR/bridge.py" "$CLOCK_HOST"


### PR DESCRIPTION
## Summary

- `bridge.py` now binds its WebSocket server to `0.0.0.0` (all interfaces) by default instead of `localhost`; Docker workflow is unchanged since port mapping controls external access
- `bridge.py` gains optional HTTP static file serving (`BRIDGE_HTTP_PORT` env var, default disabled) so `web/index.html` can be served to browsers on the LAN
- `web/index.html` derives its WebSocket URL from `window.location.hostname` instead of hardcoding `localhost`, so it works whether opened as a local file or served over HTTP from any host
- New `web/run_bridge.sh` script: runs the bridge standalone for a real physical clock on the LAN

## Test plan

- [ ] Docker sim: `./docker/run_sim.sh` → open `web/index.html` as a file → connects to `ws://localhost:8765` as before
- [ ] Real clock: `./web/run_bridge.sh <rpi-ip>` → open `http://localhost:8000/index.html` → clock data appears
- [ ] LAN browser: with `run_bridge.sh` running, open `http://<bridge-host-ip>:8000/index.html` on another machine → auto-connects to correct WebSocket host

🤖 Generated with [Claude Code](https://claude.com/claude-code)