### PR TITLE
Pah/led brightness display

### DIFF
--- a/src/iot_clock.adb
+++ b/src/iot_clock.adb
@@ -236,12 +236,20 @@ begin -- IOT_Clock
       Update_interval := 1.0 / Duration (Update_Rate (S_Mode));
       Update_Count := 1;
       loop -- Update loop
-         Ambient_Light := Get_Ambient_Light;
+         declare
+            Override : constant Greyscales := Get_Ambient_Override;
+         begin
+            if Override > Greyscales'First then
+               Ambient_Light := Override;
+            else
+               Ambient_Light := Get_Ambient_Light;
+            end if; -- Override > Greyscales'First
+         end;
          if Ambient_Light > Minimum_Brightness then
             Display_Brightness := Ambient_Light;
          else
             Display_Brightness := Minimum_Brightness;
-         end if; -- Get_Ambient_Light > Minimum_Brightness
+         end if; -- Ambient_Light > Minimum_Brightness
          Update_Sweep (Next_Time, Display_Brightness, S_Mode, Gamma);
          Update_Primary (Next_Time, Display_Brightness);
          if Update_Count = 1 then

--- a/src/shared_user_interface.ads
+++ b/src/shared_user_interface.ads
@@ -9,6 +9,7 @@
 -- 20220609 : Port to 64 bit native compiler, Driver_Types renamed to
 -- TLC5940_Driver_Types. Stop_Clock removed.
 -- 20220126 : Diagnostic_Toggle addded to Request_Records and Status_Records.
+-- 20250323 : LED_Arrays changed from Boolean to Greyscales to carry PWM brightness.
 -- 20220125 : Status_Records no longer variant, Null_Request removed. User
 -- interface only stores lit state od LEDs.
 -- 20220122 : Volume_Test added;
@@ -42,8 +43,8 @@ package Shared_User_Interface is
    end record; -- Request_Records
 
    subtype UI_Strings is String (1 .. 80);
-   type LED_Arrays is array (LED_Drivers, LED_Channels) of Boolean;
-   -- Record lit state only
+   type LED_Arrays is array (LED_Drivers, LED_Channels) of Greyscales;
+   -- Record greyscale brightness (0 = off)
 
    type Status_Records is record
       Clock_Version : Version_String := "YYYYMMDD";
@@ -56,7 +57,7 @@ package Shared_User_Interface is
       Chime_Volume : Chime_Volumes := Chime_Volumes'First;
       Ambient_Light, AL_Test_Value : Greyscales := Greyscales'First;
       Current_Item : UI_Strings := (others => ' ');
-      LED_Array : LED_Arrays := (others => (others => False));
+      LED_Array : LED_Arrays := (others => (others => Greyscales'First));
    end record; -- Status_Records
    -- All but Current_Time initialised to ensure legal values for Update_Screen
    -- in User_Interface_Client

--- a/src/shared_user_interface.ads
+++ b/src/shared_user_interface.ads
@@ -10,6 +10,7 @@
 -- TLC5940_Driver_Types. Stop_Clock removed.
 -- 20220126 : Diagnostic_Toggle addded to Request_Records and Status_Records.
 -- 20250323 : LED_Arrays changed from Boolean to Greyscales to carry PWM brightness.
+-- 20250323 : Ambient_Override added to Request_Records for simulator ambient injection.
 -- 20220125 : Status_Records no longer variant, Null_Request removed. User
 -- interface only stores lit state od LEDs.
 -- 20220122 : Volume_Test added;
@@ -40,6 +41,8 @@ package Shared_User_Interface is
       User_Interface_Version : Version_String := Interface_Version;
       Request : Requests;
       Diagnostic_Toggle : Boolean := False;
+      Ambient_Override : Greyscales := Greyscales'First;
+      -- Simulator: 0 = use sensor; >0 = override ambient light with this value.
    end record; -- Request_Records
 
    subtype UI_Strings is String (1 .. 80);

--- a/src/user_interface_client.adb
+++ b/src/user_interface_client.adb
@@ -364,11 +364,11 @@ package body User_Interface_Client is
             for D in LED_Drivers loop
                for C in LED_Channels loop
                   if Full_Update or else
-                    (Status.LED_Array (D, C) xor
+                    (Status.LED_Array (D, C) /=
                          Previous_Status.LED_Array (D, C)) then
                      Goto_XY (LED_Data (D, C).X + Origin_X,
                               LED_Data (D, C).Y + Origin_Y);
-                     if Status.LED_Array (D, C) then
+                     if Status.LED_Array (D, C) > Greyscales'First then
                         Put (LED_Data (D, C).Active);
                      else
                         Put (Passive);

--- a/src/user_interface_server.adb
+++ b/src/user_interface_server.adb
@@ -249,8 +249,7 @@ package body User_Interface_Server is
          -- Provides for reporting of LED state to the User Interface.
 
       begin -- Report_LED
-         UI_Data.Clock_Status.LED_Array (Driver, Channel) :=
-           Greyscale > Greyscales'First;
+         UI_Data.Clock_Status.LED_Array (Driver, Channel) := Greyscale;
       end Report_LED;
 
       procedure Report_Clock_Version (Clock_Version : Version_String) is

--- a/src/user_interface_server.adb
+++ b/src/user_interface_server.adb
@@ -38,6 +38,12 @@ package body User_Interface_Server is
       -- Returns true if chiming is turned on in UI, defaults to true on
       -- startup.
 
+      function Get_Ambient_Override return Greyscales;
+      -- Returns the ambient light override; 0 = no override.
+
+      procedure Set_Ambient_Override (Override : in Greyscales);
+      -- Stores the ambient light override from the UI request.
+
       procedure Report_Chiming (Chiming_Enabled : in Boolean;
                                 Chime_Volume : in Chime_Volumes);
       -- Provides for reporting of current chime state to user interface.
@@ -71,6 +77,7 @@ package body User_Interface_Server is
    private
 
       Clock_Status : Status_Records;
+      Ambient_Override_Value : Greyscales := Greyscales'First;
 
    end UI_Data;
 
@@ -78,6 +85,8 @@ package body User_Interface_Server is
    end UI_Server;
 
    function Get_Chime_Toggle return Boolean is (UI_Data.Get_Chime_Toggle);
+
+   function Get_Ambient_Override return Greyscales is (UI_Data.Get_Ambient_Override);
 
       -- Returns true if chiming is turned on in UI, defaults to true on
       --startup.
@@ -163,6 +172,7 @@ package body User_Interface_Server is
          -- Returns after after Receive_Timeout or when packet received.
          if Request_Record.User_Interface_Version = Interface_Version then
             -- only action commands with matching interface version
+            UI_Data.Set_Ambient_Override (Request_Record.Ambient_Override);
             Client_Address.Port := Response_Port;
             case Request_Record.Request is
             when Toggle_Chime =>
@@ -192,6 +202,14 @@ package body User_Interface_Server is
 
       function Get_Chime_Toggle return Boolean is
         (UI_Data.Clock_Status.Chime_Toggle);
+
+      function Get_Ambient_Override return Greyscales is
+        (UI_Data.Ambient_Override_Value);
+
+      procedure Set_Ambient_Override (Override : in Greyscales) is
+      begin -- Set_Ambient_Override
+         UI_Data.Ambient_Override_Value := Override;
+      end Set_Ambient_Override;
 
          -- Returns true if chiming is turned on in UI, defaults to true on
          --startup.

--- a/src/user_interface_server.ads
+++ b/src/user_interface_server.ads
@@ -25,6 +25,10 @@ package User_Interface_Server is
    function Get_Chime_Toggle return Boolean;
    -- Returns true if chiming is turned on in UI, defaults to true on startup.
 
+   function Get_Ambient_Override return Greyscales;
+   -- Returns the ambient light override value set via the UI.
+   -- 0 = no override (use sensor); >0 = override with this greyscale value.
+
    procedure Report_Chiming (Chiming_Enabled : in Boolean;
                              Chime_Volume : in Chime_Volumes);
    -- Provides for reporting of current chime state to user interface.

--- a/web/bridge.py
+++ b/web/bridge.py
@@ -46,10 +46,10 @@ Each row: channels 0-7 = tens digit (segs a,b,c,d,e,f,g,DP)
 
 Request_Records (16 bytes):
   off  0   8s    User_Interface_Version
-  off  8   I     Request                Requests enum (uint32)
-  off 12   ?     Diagnostic_Toggle      Boolean
-  off 13   1x    padding
-  off 14   H     Ambient_Override       Greyscales (uint16); 0 = use sensor
+  off  8   B     Request                Requests enum (uint8 — same 1-byte repr as in Status_Records)
+  off  9   ?     Diagnostic_Toggle      Boolean
+  off 10   H     Ambient_Override       Greyscales (uint16); 0 = use sensor
+  off 12   4x    padding
 Total: 16 bytes  (Request_Records'Size = 128 bits)
 
 Ada.Calendar.Time on GNAT/Linux = nanoseconds since Jan 1 1970 (POSIX epoch).
@@ -100,7 +100,7 @@ REQUEST_ENUM = {
 
 # ── Struct formats ────────────────────────────────────────────────────────────
 STATUS_FMT   = "<8sB?8s6xq??2xiHH80s160H"
-REQUEST_FMT  = "<8sI?xH"
+REQUEST_FMT  = "<8sB?H4x"
 
 STATUS_SIZE  = struct.calcsize(STATUS_FMT)   # must be 444
 REQUEST_SIZE = struct.calcsize(REQUEST_FMT)  # must be 16

--- a/web/bridge.py
+++ b/web/bridge.py
@@ -48,7 +48,8 @@ Request_Records (16 bytes):
   off  0   8s    User_Interface_Version
   off  8   I     Request                Requests enum (uint32)
   off 12   ?     Diagnostic_Toggle      Boolean
-  off 13   3x    padding
+  off 13   1x    padding
+  off 14   H     Ambient_Override       Greyscales (uint16); 0 = use sensor
 Total: 16 bytes  (Request_Records'Size = 128 bits)
 
 Ada.Calendar.Time on GNAT/Linux = nanoseconds since Jan 1 1970 (POSIX epoch).
@@ -99,7 +100,7 @@ REQUEST_ENUM = {
 
 # ── Struct formats ────────────────────────────────────────────────────────────
 STATUS_FMT   = "<8sB?8s6xq??2xiHH80s160H"
-REQUEST_FMT  = "<8sI?3x"
+REQUEST_FMT  = "<8sI?xH"
 
 STATUS_SIZE  = struct.calcsize(STATUS_FMT)   # must be 444
 REQUEST_SIZE = struct.calcsize(REQUEST_FMT)  # must be 16
@@ -187,23 +188,30 @@ def decode_status(data: bytes) -> dict:
     }
 
 # ── Request encode ────────────────────────────────────────────────────────────
-def encode_request(request_name: str, diag_toggle: bool = False) -> bytes:
+def encode_request(request_name: str, diag_toggle: bool = False,
+                   ambient_override: int = 0) -> bytes:
     enum_val = REQUEST_ENUM.get(request_name, REQUEST_ENUM["Get_Status"])
-    return _REQUEST_STRUCT.pack(INTERFACE_VERSION, enum_val, diag_toggle)
+    return _REQUEST_STRUCT.pack(INTERFACE_VERSION, enum_val, diag_toggle,
+                                ambient_override)
 
 # ── WebSocket server ──────────────────────────────────────────────────────────
 connected_clients: set = set()
 _udp_tx: socket.socket | None = None
+_ambient_override: int = 0   # 0 = use sensor; >0 = simulator override
 
 
 async def ws_handler(websocket):
+    global _ambient_override
     connected_clients.add(websocket)
     logging.info("Browser connected  (total: %d)", len(connected_clients))
     try:
         async for raw in websocket:
             try:
                 cmd = json.loads(raw)
-                pkt = encode_request(cmd.get("request", "Get_Status"))
+                if "ambient_override" in cmd:
+                    _ambient_override = int(cmd["ambient_override"]) & 0xFFFF
+                pkt = encode_request(cmd.get("request", "Get_Status"),
+                                     ambient_override=_ambient_override)
                 _udp_tx.sendto(pkt, (CLOCK_HOST, REQUEST_PORT))
             except Exception as exc:
                 logging.warning("Bad browser command: %s", exc)
@@ -242,10 +250,10 @@ async def udp_receive_loop(udp: socket.socket) -> None:
 
 
 async def poll_clock(udp: socket.socket) -> None:
-    """Send Get_Status once per second to keep the server responding."""
-    pkt = encode_request("Get_Status")
+    """Send Get_Status at 8 Hz to keep the server responding."""
     while True:
         try:
+            pkt = encode_request("Get_Status", ambient_override=_ambient_override)
             udp.sendto(pkt, (CLOCK_HOST, REQUEST_PORT))
         except Exception:
             pass

--- a/web/bridge.py
+++ b/web/bridge.py
@@ -31,8 +31,8 @@ Status_Records (284 bytes):
   off 40   H     Ambient_Light          Unsigned_16
   off 42   H     AL_Test_Value          Unsigned_16
   off 44   80s   Current_Item           String(1..80)
-  off 124  160?  LED_Array              array(10 drivers × 16 channels) of Boolean
-Total: 284 bytes  (Status_Records'Size = 2272 bits, no trailing padding)
+  off 124  160H  LED_Array              array(10 drivers × 16 channels) of Greyscales (uint16)
+Total: 444 bytes  (Status_Records'Size = 3552 bits, no trailing padding)
 
 Layout verified empirically: ui_version decoded as '50510\\x00\\x00\\x00' with old
 'I' (4-byte) format confirmed Request is 1 byte (GNAT uses smallest integer type).
@@ -55,7 +55,7 @@ Ada.Calendar.Time on GNAT/Linux = nanoseconds since Jan 1 1970 (POSIX epoch).
 If the value looks unreasonable the bridge falls back to datetime.now().
 
 Layout verification (add to a test Ada program):
-  Put_Line(Status_Records'Size'Image);   -- expect 2304
+  Put_Line(Status_Records'Size'Image);   -- expect 3552
   Put_Line(Request_Records'Size'Image);  -- expect 128
 """
 
@@ -98,13 +98,13 @@ REQUEST_ENUM = {
 }
 
 # ── Struct formats ────────────────────────────────────────────────────────────
-STATUS_FMT   = "<8sB?8s6xq??2xiHH80s160?"
+STATUS_FMT   = "<8sB?8s6xq??2xiHH80s160H"
 REQUEST_FMT  = "<8sI?3x"
 
-STATUS_SIZE  = struct.calcsize(STATUS_FMT)   # must be 288
+STATUS_SIZE  = struct.calcsize(STATUS_FMT)   # must be 444
 REQUEST_SIZE = struct.calcsize(REQUEST_FMT)  # must be 16
 
-assert STATUS_SIZE  == 284, f"STATUS_FMT calcsize={STATUS_SIZE}, expected 284"
+assert STATUS_SIZE  == 444, f"STATUS_FMT calcsize={STATUS_SIZE}, expected 444"
 assert REQUEST_SIZE == 16,  f"REQUEST_FMT calcsize={REQUEST_SIZE}, expected 16"
 
 _STATUS_STRUCT  = struct.Struct(STATUS_FMT)
@@ -165,11 +165,11 @@ def decode_status(data: bytes) -> dict:
     # 8  ambient_light  (uint16)
     # 9  al_test_value  (uint16)
     # 10 current_item   (bytes)
-    # 11..170  160 LED booleans
+    # 11..170  160 LED greyscale values (uint16, 0-4095)
 
-    led_bools = unpacked[11:]   # 160 elements
+    led_vals = unpacked[11:]   # 160 elements
     leds = [
-        [bool(led_bools[r * 16 + c]) for c in range(16)]
+        [led_vals[r * 16 + c] for c in range(16)]
         for r in range(10)
     ]
 

--- a/web/debug_leds_raw.py
+++ b/web/debug_leds_raw.py
@@ -45,10 +45,12 @@ def print_status(data: dict, n: int = 0) -> None:
     print(f"  lit LEDs     : {total_lit} / {total_ch}")
     for r, row in enumerate(leds):
         name = DRIVER_NAMES[r] if r < len(DRIVER_NAMES) else f"row{r}"
-        bits = [int(v) for v in row]
-        lit = [i for i, v in enumerate(bits) if v]
-        status = f"ch {lit}" if lit else "(all off)"
-        print(f"    [{r}] {name:16s}: {status}")
+        active = [(i, v) for i, v in enumerate(row) if v]
+        if active:
+            ch_str = "  ".join(f"ch{i}={v}" for i, v in active)
+            print(f"    [{r}] {name:16s}: {ch_str}")
+        else:
+            print(f"    [{r}] {name:16s}: (all off)")
 
 
 async def run() -> None:

--- a/web/debug_raw_bytes.py
+++ b/web/debug_raw_bytes.py
@@ -23,11 +23,13 @@ for arg in sys.argv[1:]:
     elif not arg.startswith("--"):
         HOST = arg
 
-REQUEST_FMT = "<8sI?3x"
-STATUS_SIZE_EXPECTED = 284
+# Request: 1-byte enum (same repr as in Status_Records), 1-byte bool,
+# 2-byte Ambient_Override, 4 bytes padding = 16 bytes total.
+REQUEST_FMT = "<8sB?H4x"
+STATUS_SIZE_EXPECTED = 444
 
 def send_get_status(sock):
-    pkt = struct.pack(REQUEST_FMT, b"20250510", 5, False)   # Get_Status = 5
+    pkt = struct.pack(REQUEST_FMT, b"20250510", 5, False, 0)   # Get_Status = 5
     sock.sendto(pkt, (HOST, 50003))
 
 def hexdump(data, width=16):
@@ -37,31 +39,30 @@ def hexdump(data, width=16):
         ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
         print(f"  {i:4d}  {hex_part:<{width*3}}  {ascii_part}")
 
-# Field layout for annotation (matches bridge.py STATUS_FMT: <8sB?8s6xq??2xiHH80s160?)
+# Field layout for annotation (matches bridge.py STATUS_FMT: <8sB?8s6xq??2xiHH80s160H)
 FIELDS = [
-    (0,   8,  "Clock_Version (String 1..8)"),
-    (8,   1,  "Request (enum uint8)"),
-    (9,   1,  "Diagnostic_Toggle (bool)"),
-    (10,  8,  "User_Interface_Version (String 1..8)"),
-    (18,  6,  "padding (6x)"),
-    (24,  8,  "Current_Time (int64 ns)"),
-    (32,  1,  "Chime_Enabled (bool)"),
-    (33,  1,  "Chime_Toggle (bool)"),
-    (34,  2,  "padding (2x)"),
-    (36,  4,  "Chime_Volume (int32)"),
-    (40,  2,  "Ambient_Light (uint16)"),
-    (42,  2,  "AL_Test_Value (uint16)"),
-    (44, 80,  "Current_Item (String 1..80)"),
-    (124,160, "LED_Array (160 bool)"),
+    (0,   8,   "Clock_Version (String 1..8)"),
+    (8,   1,   "Request (enum uint8)"),
+    (9,   1,   "Diagnostic_Toggle (bool)"),
+    (10,  8,   "User_Interface_Version (String 1..8)"),
+    (18,  6,   "padding (6x)"),
+    (24,  8,   "Current_Time (int64 ns)"),
+    (32,  1,   "Chime_Enabled (bool)"),
+    (33,  1,   "Chime_Toggle (bool)"),
+    (34,  2,   "padding (2x)"),
+    (36,  4,   "Chime_Volume (int32)"),
+    (40,  2,   "Ambient_Light (uint16)"),
+    (42,  2,   "AL_Test_Value (uint16)"),
+    (44,  80,  "Current_Item (String 1..80)"),
+    (124, 320, "LED_Array (160 × uint16 greyscale, 0-4095)"),
 ]
 
 def annotate(data):
     print(f"\nAnnotated fields ({len(data)} bytes):")
     for off, size, name in FIELDS:
         chunk = data[off:off+size]
-        hex_s = " ".join(f"{b:02x}" for b in chunk[:min(size,20)])
+        hex_s = " ".join(f"{b:02x}" for b in chunk[:min(size, 20)])
         extra = "..." if size > 20 else ""
-        # Try to decode as useful type
         note = ""
         if "String" in name:
             note = repr(chunk.decode("ascii", errors="replace"))
@@ -75,8 +76,10 @@ def annotate(data):
         elif size == 1:
             note = str(chunk[0])
         elif "LED" in name:
-            lit = sum(1 for b in chunk if b)
-            note = f"{lit}/160 lit"
+            vals = struct.unpack_from(f"<{size//2}H", chunk)
+            lit = sum(1 for v in vals if v)
+            max_v = max(vals) if vals else 0
+            note = f"{lit}/160 lit, max greyscale={max_v}"
         print(f"  off {off:3d} [{size:3d}B]  {hex_s}{extra}  {name}  {note}")
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -88,6 +91,8 @@ for i in range(COUNT):
     try:
         data, addr = sock.recvfrom(4096)
         print(f"\n=== Response {i+1} from {addr} ({len(data)} bytes) ===")
+        if len(data) != STATUS_SIZE_EXPECTED:
+            print(f"  WARNING: expected {STATUS_SIZE_EXPECTED} bytes, got {len(data)}")
         hexdump(data)
         annotate(data)
     except socket.timeout:

--- a/web/debug_ws.py
+++ b/web/debug_ws.py
@@ -42,10 +42,11 @@ def print_status(data: dict, n: int = 0) -> None:
     total_lit = sum(1 for row in leds for v in row if v)
     print(f"  lit LEDs     : {total_lit} / {len(leds) * (len(leds[0]) if leds else 0)}")
     for r, row in enumerate(leds):
-        ones = [i for i, v in enumerate(row) if v]
         name = LED_DRIVER_NAMES[r] if r < len(LED_DRIVER_NAMES) else f"row{r}"
-        if ones:
-            print(f"    [{r}] {name:16s}: ch {ones}")
+        active = [(i, v) for i, v in enumerate(row) if v]
+        if active:
+            ch_str = "  ".join(f"ch{i}={v}" for i, v in active)
+            print(f"    [{r}] {name:16s}: {ch_str}")
         else:
             print(f"    [{r}] {name:16s}: (all off)")
 

--- a/web/index.html
+++ b/web/index.html
@@ -133,7 +133,7 @@
     border: 1px solid var(--border);
     border-radius: 8px;
     padding: 16px;
-    min-width: 220px;
+    width: 240px;
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -208,6 +208,7 @@
   <span class="sep">|</span>
   <button id="display-mode-btn">Displays: Inside</button>
   <button id="pcb-details-btn">PCB detail: On</button>
+  <button id="seg-brightness-btn">Seg brightness: On</button>
 </div>
 
 <div id="main">
@@ -305,9 +306,9 @@
         <span class="stat-label">Ambient light</span>
         <span class="stat-value" id="stat-ambient">—</span>
       </div>
-      <div class="stat-row" style="align-items:flex-start;">
+      <div class="stat-row">
         <span class="stat-label">Secondary</span>
-        <span class="stat-value" id="stat-item" style="word-break:break-all;max-width:130px;">—</span>
+        <span class="stat-value" id="stat-item" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:150px;">—</span>
       </div>
       <div class="stat-row">
         <span class="stat-label">Clock version</span>
@@ -383,7 +384,7 @@ function buildDigit(svgEl) {
     const vals = [ch0, ch1, ch2, ch3, ch4, ch5, ch6, ch7];
     const segNames = ['a','b','c','d','e','f','g','dp'];
     segNames.forEach((name, i) => {
-      const intensity = ledIntensity(vals[i]);
+      const intensity = segBrightnessEnabled ? ledIntensity(vals[i]) : (vals[i] ? 1.0 : 0.0);
       paths[name].setAttribute('fill-opacity', (0.08 + intensity * 0.92).toFixed(3));
     });
   };
@@ -469,11 +470,14 @@ MARKER_POSITIONS.forEach(pos => {
 });
 
 // ── Dimming-ready intensity helper ────────────────────────────────────────
-// Handles current boolean values and future numeric (0-4095) values.
+// Handles boolean values and numeric (0-4095) values.
 function ledIntensity(v) {
   if (typeof v === 'boolean') return v ? 1.0 : 0.0;
   return Math.min(1.0, Math.max(0.0, v / 4095));
 }
+
+// Whether 7-segment digits reflect PWM brightness (vs binary on/off)
+let segBrightnessEnabled = true;
 
 // ── LED array update ───────────────────────────────────────────────────────
 function updateLEDs(leds) {
@@ -568,6 +572,14 @@ function setDisplayMode(mode) {
   localStorage.setItem('displayMode', mode);
 }
 
+// ── Configuration: segment brightness ────────────────────────────────────
+function setSegBrightness(enabled) {
+  segBrightnessEnabled = enabled;
+  document.getElementById('seg-brightness-btn').textContent =
+    'Seg brightness: ' + (enabled ? 'On' : 'Off');
+  localStorage.setItem('segBrightness', enabled ? '1' : '0');
+}
+
 // ── Configuration: PCB detail ─────────────────────────────────────────────
 function setPcbDetails(show) {
   const group = document.getElementById('pcb-details');
@@ -587,6 +599,9 @@ function setPcbDetails(show) {
 
   const pcb = localStorage.getItem('pcbDetails');
   if (pcb === '0') setPcbDetails(false);
+
+  const segBr = localStorage.getItem('segBrightness');
+  if (segBr === '0') setSegBrightness(false);
 })();
 
 // ── Config bar event listeners ─────────────────────────────────────────────
@@ -606,6 +621,10 @@ document.getElementById('display-mode-btn').addEventListener('click', () => {
 document.getElementById('pcb-details-btn').addEventListener('click', () => {
   const current = localStorage.getItem('pcbDetails');
   setPcbDetails(current === '0' ? true : false);
+});
+
+document.getElementById('seg-brightness-btn').addEventListener('click', () => {
+  setSegBrightness(!segBrightnessEnabled);
 });
 
 // ── WebSocket ──────────────────────────────────────────────────────────────

--- a/web/index.html
+++ b/web/index.html
@@ -158,6 +158,18 @@
     flex-direction: column;
     gap: 6px;
   }
+  /* ── Ambient override slider ─────────────────────────────────── */
+  #ambient-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-top: 1px solid var(--border);
+    margin-top: 2px;
+  }
+  #ambient-row label { color: var(--dim); white-space: nowrap; flex-shrink: 0; }
+  #ambient-slider { flex: 1; accent-color: var(--led-color); }
+  #ambient-val { color: var(--text); min-width: 48px; text-align: right; font-size: 0.78rem; white-space: nowrap; }
   .ctrl-btn {
     display: flex;
     align-items: center;
@@ -323,6 +335,11 @@
       <button class="ctrl-btn" data-cmd="Volume_Down"><kbd>−</kbd> Volume down</button>
       <button class="ctrl-btn" data-cmd="Volume_Test"><kbd>T</kbd> Volume test</button>
       <button class="ctrl-btn" data-cmd="Cycle_Sweep"><kbd>S</kbd> Cycle sweep</button>
+      <div id="ambient-row">
+        <label for="ambient-slider">Ambient</label>
+        <input type="range" id="ambient-slider" min="0" max="4095" value="0" step="1">
+        <span id="ambient-val">auto</span>
+      </div>
     </div>
   </div>
 </div><!-- /main -->
@@ -667,9 +684,11 @@ function connect() {
 connect();
 
 // ── Controls ───────────────────────────────────────────────────────────────
+let _ambientOverride = 0;
+
 function sendCmd(cmd) {
   if (ws && ws.readyState === WebSocket.OPEN)
-    ws.send(JSON.stringify({request: cmd}));
+    ws.send(JSON.stringify({request: cmd, ambient_override: _ambientOverride}));
 }
 
 document.querySelectorAll('.ctrl-btn').forEach(btn => {
@@ -689,6 +708,18 @@ document.addEventListener('keydown', evt => {
   if (evt.ctrlKey || evt.altKey || evt.metaKey) return;
   const cmd = KEY_MAP[evt.key.toLowerCase()];
   if (cmd) sendCmd(cmd);
+});
+
+// ── Ambient light override slider ──────────────────────────────────────────
+const ambientSlider = document.getElementById('ambient-slider');
+const ambientVal    = document.getElementById('ambient-val');
+
+ambientSlider.addEventListener('input', () => {
+  _ambientOverride = parseInt(ambientSlider.value, 10);
+  ambientVal.textContent = _ambientOverride === 0 ? 'auto' : _ambientOverride;
+  // Send immediately so the clock responds without waiting for next poll
+  if (ws && ws.readyState === WebSocket.OPEN)
+    ws.send(JSON.stringify({request: 'Get_Status', ambient_override: _ambientOverride}));
 });
 </script>
 </body>


### PR DESCRIPTION


https://github.com/user-attachments/assets/b4dbe746-bcf1-48ce-9d36-77117cc807d6


Maybe this should feeding ambient light data to the stub instead?

Implementation summary from Claude
---
**The boundary: Ada clock code vs. simulator/web layer**

  The Ada clock code was left almost entirely unchanged. The only modification to core clock logic was a single block in `iot_clock.adb` — the main loop now checks for an ambient override before falling back to the hardware sensor:

```
Override := Get_Ambient_Override;   -- new call to UI server
if Override > 0 then
   Ambient_Light := Override;       -- use slider value
else
   Ambient_Light := Get_Ambient_Light;  -- use TLC5940 binary search result
end if;
```

Everything else stayed the same: the sweep tail logic, brightness scaling, digit updates, `Write_LEDs` — all untouched.

**The wire format changes (Ada ↔ bridge)**

  Two Ada data structures were modified in `shared_user_interface.ads`, which defines the UDP protocol between the clock process and any client:

  - LED_Arrays: element type changed from `Boolean` → `Greyscales` (`Unsigned_16`). The status packet grew from 284 → 444 bytes. This lets the clock transmit actual PWM values rather than on/off bits.
  - `Request_Records`: one new field `Ambient_Override : Greyscales` added into the existing 4 bytes of trailing padding, so the packet stayed at 16 bytes.

  The `user_interface_server` (which lives inside the clock process) was extended to store and expose the override value — same pattern as the existing `Get_Chime_Toggle` mechanism.

**The bridge (`web/bridge.py`)**

  This Python process is the adapter between the Ada UDP protocol and the browser WebSocket. It:
  - Decodes Ada binary packets → JSON for the browser (160H greyscale values instead of 160? booleans)
  - Encodes browser JSON commands → Ada binary requests (now including ambient_override)
  - Maintains `_ambient_override` state so every poll packet carries the current slider value

**The browser (`web/index.html`)**

  Purely cosmetic/UI. The `ledIntensity()` function already existed and already handled numeric values — it just never received any because the wire was boolean. The new work here was:
  - Ambient slider → `sends ambient_override` field with every request
  - Segment brightness toggle → `segBrightnessEnabled` flag gates whether digit segments use the greyscale value or binary on/off
  - Layout fix for the status panel

**What the simulator does vs. the real clock**

  On real hardware, `Get_Ambient_Light` reads from the TLC5940's successive-approximation circuit (a 12-step binary search using a GPIO comparator pin). In the simulator the GPIO stub always returns `False`, so the binary search converges to 0 — the clock would always run at minimum
  brightness. The ambient override slider bypasses this entirely, letting you inject any brightness level directly into the Ada main loop without touching the measurement hardware path at all.